### PR TITLE
Add BrainViewer and path alias

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "tailwindcss": "^3.4.5",
         "typescript": "^5.1.3",
         "vite": "^4.4.9",
+        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.2.4",
       },
     },
@@ -628,6 +629,8 @@
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
+    "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
+
     "glsl-noise": ["glsl-noise@0.0.0", "", {}, "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
@@ -1098,6 +1101,8 @@
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
+    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
+
     "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
@@ -1129,6 +1134,8 @@
     "vite": ["vite@4.5.14", "", { "dependencies": { "esbuild": "^0.18.10", "postcss": "^8.4.27", "rollup": "^3.27.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@types/node": ">= 14", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 
     "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "tailwindcss": "^3.4.5",
     "typescript": "^5.1.3",
     "vite": "^4.4.9",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,12 @@
 import React, { Suspense } from 'react';
 const BrainMap = React.lazy(() => import('./components/BrainMap'));
+const BrainViewer = React.lazy(() => import('@/components/BrainViewer'));
 import { StateController } from './components/StateController';
+
+const highlightMap: Record<string, string[]> = {
+  Anxious: ['leftAmygdala', 'rightAmygdala'],
+  Flow: ['leftFrontalLobe', 'rightFrontalLobe'],
+};
 
 export default function App() {
   const [activeState, setActiveState] = React.useState('Flow');
@@ -16,6 +22,7 @@ export default function App() {
       />
       <Suspense fallback={<div>Loading...</div>}>
         <BrainMap activeState={activeState} />
+        <BrainViewer highlightedRegions={highlightMap[activeState] ?? []} />
       </Suspense>
     </div>
   );

--- a/src/components/BrainViewer.test.tsx
+++ b/src/components/BrainViewer.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import BrainViewer from './BrainViewer';
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="canvas">{children}</div>
+  ),
+  useFrame: vi.fn(),
+}));
+
+vi.mock('@react-three/drei', () => ({
+  OrbitControls: () => null,
+  useGLTF: Object.assign(() => ({ scene: { traverse: vi.fn() } }), {
+    preload: vi.fn(),
+  }),
+}));
+
+describe('BrainViewer', () => {
+  it('renders a canvas', () => {
+    const { getByTestId } = render(
+      <BrainViewer highlightedRegions={['test']} />
+    );
+    expect(getByTestId('canvas')).toBeInTheDocument();
+  });
+});

--- a/src/components/BrainViewer.tsx
+++ b/src/components/BrainViewer.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable react/no-unknown-property */
+import React, { Suspense, useRef } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, useGLTF } from '@react-three/drei';
+import * as THREE from 'three';
+import { Card, CardContent } from '@/components/ui/card';
+
+/**
+ * BrainModel loads a 3D brain GLTF and applies highlighting
+ * @param {Array<string>} highlightRegions - names of regions to emphasize
+ */
+function BrainModel({
+  highlightRegions = [],
+}: {
+  highlightRegions?: string[];
+}) {
+  const gltf = useGLTF('/models/brain.glb');
+  const group = useRef<THREE.Group>(null);
+
+  // subtle rotation animation
+  useFrame(() => {
+    if (group.current) {
+      group.current.rotation.y += 0.002;
+    }
+  });
+
+  // apply highlight on regions
+  React.useEffect(() => {
+    gltf.scene.traverse((child: THREE.Object3D) => {
+      const mesh = child as THREE.Mesh;
+      if (mesh.isMesh) {
+        const mat = mesh.material as THREE.MeshStandardMaterial;
+        if (highlightRegions.includes(mesh.name)) {
+          mat.emissiveIntensity = 0.8;
+          mat.emissive.setHex(0xffd54f);
+        } else {
+          mat.emissiveIntensity = 0;
+        }
+        mat.transparent = true;
+        mat.opacity = highlightRegions.length
+          ? highlightRegions.includes(mesh.name)
+            ? 1
+            : 0.5
+          : 1;
+      }
+    });
+  }, [gltf, highlightRegions]);
+
+  return <primitive ref={group} object={gltf.scene} />;
+}
+
+/**
+ * BrainViewer displays the 3D brain in a styled card and replaces previous card UI
+ * @param {Array<string>} highlightedRegions - optional regions to emphasize
+ */
+export default function BrainViewer({
+  highlightedRegions = [],
+}: {
+  highlightedRegions?: string[];
+}) {
+  return (
+    <Card className="w-full h-[600px] rounded-2xl shadow-md">
+      <CardContent className="p-0 w-full h-full">
+        <Canvas camera={{ position: [0, 0, 2], fov: 50 }}>
+          <ambientLight intensity={0.5} />
+          <directionalLight position={[1, 1, 1]} intensity={0.8} />
+          <Suspense fallback={null}>
+            <BrainModel highlightRegions={highlightedRegions} />
+          </Suspense>
+          <OrbitControls enablePan enableZoom enableRotate />
+        </Canvas>
+      </CardContent>
+    </Card>
+  );
+}
+
+useGLTF.preload('/models/brain.glb');

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export function Card({
+  className = '',
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={`bg-gray-800 text-white rounded-lg ${className}`}
+      {...props}
+    />
+  );
+}
+
+export function CardContent({
+  className = '',
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={`p-4 ${className}`} {...props} />;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["@react-three/fiber"]
+    "types": ["@react-three/fiber"],
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { configDefaults } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- add `vite-tsconfig-paths` for `@/*` sugar imports
- create simple `Card` component
- add new `BrainViewer` component and tests
- display `BrainViewer` in the main `App`
- generate `public/models/brain.glb` via `generate-brain`

## Testing
- `bun run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68534daf52f0832ca547585f4b7a9f6e